### PR TITLE
Add example kustomization to add the plugin to argocd

### DIFF
--- a/examples/kustomize/argocd/argo-cm.yml
+++ b/examples/kustomize/argocd/argo-cm.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  configManagementPlugins: |-
+    - name: vault-replacer
+      generate:
+        command: ["vault-replacer"]
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-cm

--- a/examples/kustomize/argocd/kustomization.yaml
+++ b/examples/kustomize/argocd/kustomization.yaml
@@ -1,4 +1,4 @@
-# kustomize build . >../argocd-deploy.yml
+# kustomize build . >argocd-deploy.yml
 #
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/examples/kustomize/argocd/kustomization.yaml
+++ b/examples/kustomize/argocd/kustomization.yaml
@@ -1,0 +1,24 @@
+# kustomize build . >../argocd-deploy.yml
+#
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+
+resources:
+- https://raw.githubusercontent.com/argoproj/argo-cd/v1.8.3/manifests/ha/install.yaml
+- vault-replacer-secret.yml
+- serviceaccount.yml
+
+patches:
+- path: argo-cm.yml
+  target:
+    kind: ConfigMap
+    name: argocd-cm
+- path: vault-replacer.yml
+  target:
+    kind: Deployment
+    name: argocd-repo-server
+- path: patch-serviceAccount.yml
+  target:
+    kind: Deployment
+    name: argocd-repo-server

--- a/examples/kustomize/argocd/patch-serviceAccount.yml
+++ b/examples/kustomize/argocd/patch-serviceAccount.yml
@@ -1,0 +1,10 @@
+# Enter the name of your chosen serviceAccount, and enable automounting
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: patch-serviceAccount
+spec:
+  template:
+    spec:
+      serviceAccount: argocd
+      automountServiceAccountToken: true

--- a/examples/kustomize/argocd/serviceaccount.yml
+++ b/examples/kustomize/argocd/serviceaccount.yml
@@ -1,0 +1,6 @@
+# Choose the name and namespace for your serviceAccount
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd
+  namespace: argocd

--- a/examples/kustomize/argocd/vault-replacer-secret.yml
+++ b/examples/kustomize/argocd/vault-replacer-secret.yml
@@ -1,0 +1,8 @@
+# Change the Vault Address to match yours (base64 encoded)
+apiVersion: v1
+data:
+  VAULT_ADDR: aHR0cHM6Ly92YXVsdC5leGFtcGxlLmJpeg==
+kind: Secret
+metadata:
+  name: argocd-vault-replacer-credentials
+type: Opaque

--- a/examples/kustomize/argocd/vault-replacer.yml
+++ b/examples/kustomize/argocd/vault-replacer.yml
@@ -1,0 +1,35 @@
+# Downloads the plugin and moves it to /custom-tools, which is then mounted on the argocd-repo-server
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vault-replacer
+spec:
+  template:
+    spec:
+      containers:
+      - name: argocd-repo-server
+        volumeMounts:
+        - name: custom-tools
+          mountPath: /usr/local/bin/vault-replacer
+          subPath: vault-replacer
+        envFrom:
+          - secretRef:
+              name: argocd-vault-replacer-credentials
+      volumes:
+      - name: custom-tools
+        emptyDir: {}
+      initContainers:
+      - name: vault-replacer-download
+        image: alpine:3.8
+        command: [sh, -c]
+        args:
+          - wget https://github.com/Joibel/vault-replacer/releases/download/0.2/vault-replacer-0.2-linux-amd64.tar.gz
+
+            tar -xvzf vault-replacer-0.2-linux-amd64.tar.gz
+          
+            chmod +x vault-replacer
+            
+            mv vault-replacer /custom-tools/
+        volumeMounts:
+          - mountPath: /custom-tools
+            name: custom-tools


### PR DESCRIPTION
This should install the latest argocd (HA) and then kustomize it to include the vault-replacer plugin.